### PR TITLE
fix: ensure checkout paths must are under github workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to point to a different repository if you are not using the official Homebrew/ho
 
 ```yaml
 steps:
-  - name: Publish Homebrew Formula
+  - name: Validate and Publish Homebrew Formula
     uses: LizardByte/homebrew-release-action@master
     with:
       formula_file: "${{ github.workspace }}/hello_world.rb"
@@ -36,7 +36,7 @@ It's possible to overwrite the defaults by providing additional inputs:
 
 ```yaml
 steps:
-  - name: Publish Homebrew Formula
+  - name: Validate and Publish Homebrew Formula
     uses: LizardByte/homebrew-release-action@master
     with:
       contribute_to_homebrew_core: true
@@ -84,7 +84,7 @@ jobs:
       run: |
         # whatever you need to do to generate the formula
 
-    - name: Publish Homebrew Formula
+    - name: Validate and Publish Homebrew Formula
       uses: LizardByte/homebrew-release-action@master
       with:
         formula_file: "${{ github.workspace }}/build/hello_world.rb"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 ---
 name: "Homebrew Release"
-description: "A reusable action to publish a Homebrew formula to a tap."
+description: "A reusable action to audit, install, test, and publish a Homebrew formula."
 author: "LizardByte"
 inputs:
   contribute_to_homebrew_core:
@@ -97,7 +97,7 @@ runs:
       with:
         repository: ${{ inputs.org_homebrew_repo }}
         ref: ${{ inputs.org_homebrew_repo_branch }}
-        path: ${{ github.action_path }}/org_homebrew_repo
+        path: ${{ github.workspace }}/homebrew-release-action/org_homebrew_repo
         persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
         fetch-depth: 1
 
@@ -106,7 +106,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: ${{ inputs.homebrew_core_fork_repo }}
-        path: ${{ github.action_path }}/homebrew_core_fork_repo
+        path: ${{ github.workspace }}/homebrew-release-action/homebrew_core_fork_repo
         persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
         fetch-depth: 1
 
@@ -138,7 +138,7 @@ runs:
         author_email: ${{ inputs.git_email }}
         author_name: ${{ inputs.git_username }}
         branch: ${{ inputs.org_homebrew_repo_branch }}  # commit to target branch
-        directory: ${{ github.action_path }}/org_homebrew_repo
+        directory: ${{ github.workspace }}/homebrew-release-action/org_homebrew_repo
         github_token: ${{ inputs.token }}
         message: "Update ${{ github.repository }} to ${{ github.sha }}"
         repository: ${{ inputs.org_homebrew_repo }}
@@ -150,7 +150,7 @@ runs:
         author_email: ${{ inputs.git_email }}
         author_name: ${{ inputs.git_username }}
         branch: ${{ steps.homebrew-tests.outputs.homebrew_core_branch }}
-        directory: ${{ github.action_path }}/homebrew_core_fork_repo
+        directory: ${{ github.workspace }}/homebrew-release-action/homebrew_core_fork_repo
         force: true  # need to force since the branch is sometimes reset
         github_token: ${{ inputs.token }}
         message: "Update ${{ github.repository }} to ${{ github.sha }}"
@@ -161,7 +161,7 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
       if: ${{ inputs.contribute_to_homebrew_core == 'true' && inputs.publish == 'true' }}
       shell: bash
-      working-directory: ${{ github.action_path }}/homebrew_core_fork_repo
+      working-directory: ${{ github.workspace }}/homebrew-release-action/homebrew_core_fork_repo
       run: |
         # Check if a pull request already exists with the same head branch
         PR_EXISTS=$(gh pr list \

--- a/action/main.py
+++ b/action/main.py
@@ -208,8 +208,10 @@ def process_input_formula(formula_file: str) -> str:
         capture_output=True
     )
 
-    org_homebrew_repo = os.path.join(os.environ['GITHUB_ACTION_PATH'], 'org_homebrew_repo')
-    homebrew_core_fork_repo = os.path.join(os.environ['GITHUB_ACTION_PATH'], 'homebrew_core_fork_repo')
+    org_homebrew_repo = os.path.join(
+        os.environ['GITHUB_WORKSPACE'], 'homebrew-release-action', 'org_homebrew_repo')
+    homebrew_core_fork_repo = os.path.join(
+        os.environ['GITHUB_WORKSPACE'], 'homebrew-release-action', 'homebrew_core_fork_repo')
     print(f'org_homebrew_repo: {org_homebrew_repo}')
     print(f'homebrew_core_fork_repo: {homebrew_core_fork_repo}')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def operating_system():
 
 @pytest.fixture(scope='function')  # todo: fix repo deletion
 def homebrew_core_fork_repo():
-    directory = os.environ['GITHUB_ACTION_PATH']
+    directory = os.path.join(os.environ['GITHUB_WORKSPACE'], 'homebrew-release-action')
     os.makedirs(directory, exist_ok=True)
 
     repo = 'homebrew_core_fork_repo'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -100,8 +100,8 @@ def test_proces_input_formula():
     assert formula == 'hello_world'
 
     dirs = [
-        os.path.join(os.environ['GITHUB_ACTION_PATH'], 'org_homebrew_repo'),
-        os.path.join(os.environ['GITHUB_ACTION_PATH'], 'homebrew_core_fork_repo'),
+        os.path.join(os.environ['GITHUB_WORKSPACE'], 'homebrew-release-action', 'org_homebrew_repo'),
+        os.path.join(os.environ['GITHUB_WORKSPACE'], 'homebrew-release-action', 'homebrew_core_fork_repo'),
     ]
 
     for d in dirs:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The action would fail if running in the context of another repository due to checkout failures.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
