### PR TITLE
tests: uninstall formula before untap

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,16 @@ def homebrew_core_fork_repo():
 
 @pytest.fixture(scope='function')
 def brew_untap():
+    # uninstall hello_world formula
+    proc = subprocess.run(
+        args=['brew', 'uninstall', 'hello_world'],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.decode('utf-8'))
+        raise Exception('Failed to uninstall hello_world formula')
+
+    # untap the temporary repo
     proc = subprocess.run(
         args=['brew', 'untap', main.temp_repo],
         capture_output=True,


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Tests are failing because the formula is still installed when trying to untap the temp repo.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
