### PR TITLE
docs(readme): remove macos-12 from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,10 @@ jobs:
       include:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         # while GitHub has larger macOS runners, they are not available for our repos :(
-        - os: macos-12
-          publish: true
         - os: macos-13
         - os: macos-14
-        - os: ubuntu-20.04
-        - os: ubuntu-22.04
+        - os: ubuntu-latest
+          publish: true
   name: Homebrew (${{ matrix.os }})
   runs-on: ${{ matrix.os }}
   steps:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
macos-12 runners are deprecated and will soon be removed.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
