### PR TITLE
fix(env): set buildpath as env variable

### DIFF
--- a/tests/Formula/hello_world.rb
+++ b/tests/Formula/hello_world.rb
@@ -21,5 +21,16 @@ class HelloWorld < Formula
     system "#{bin}/hello-world"
 
     puts "testpath: #{testpath}"
+
+    # test the env
+    if ENV["HOMEBREW_BUILDPATH"]
+      dummy_filename = "dummy.txt"
+      cd File.join(ENV["HOMEBREW_BUILDPATH"]) do
+        # create a dummy file
+        File.write(dummy_filename, "Hello, World!")
+        assert_path_exists dummy_filename
+      end
+      assert_path_exists File.join(ENV["HOMEBREW_BUILDPATH"], dummy_filename)
+    end
   end
 end


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`buildpath` is not available inside the `test do` block, so we can set an env variable that we can access instead.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
